### PR TITLE
Fix compatibility with C# queries

### DIFF
--- a/NamelessInteractive.FSharp.MongoDB/Conventions.fs
+++ b/NamelessInteractive.FSharp.MongoDB/Conventions.fs
@@ -18,19 +18,18 @@ type RecordConvention() =
 
     interface IClassMapConvention with
         member this.Apply(classMap) =
-         let objType = classMap.ClassType
+            let objType = classMap.ClassType
 
-         if IsRecord objType then
-            classMap.SetIgnoreExtraElements(true)
-            let fields = GetRecordFields objType
-            let names = fields |> Array.map (fun x -> x.Name)
-            let types = fields |> Array.map (fun x -> x.PropertyType)
+            if IsRecord objType then
+                classMap.SetIgnoreExtraElements(true)
+                let fields = GetRecordFields objType
+                let names = fields |> Array.map (fun x -> x.Name)
+                let types = fields |> Array.map (fun x -> x.PropertyType)
 
-            let ctor = objType.GetConstructor(types)
+                let ctor = objType.GetConstructor(types)
             
-            classMap.MapConstructor(ctor) |> ignore
-            fields |> Array.iter (fun x -> classMap.MapMember(x) |> ignore)
-    
+                classMap.MapConstructor(ctor, names) |> ignore
+                fields |> Array.iter (fun x -> classMap.MapMember(x) |> ignore)
 
 module ConventionsModule = 
     let mutable private isRegistered = false

--- a/NamelessInteractive.FSharp.MongoDB/DiscriminatedUnionSerializer.fs
+++ b/NamelessInteractive.FSharp.MongoDB/DiscriminatedUnionSerializer.fs
@@ -2,7 +2,6 @@
 
 open NamelessInteractive.FSharp.MongoDB
 open Microsoft.FSharp.Reflection
-open System
 open MongoDB.Bson.Serialization
 open MongoDB.Bson.Serialization.Serializers
 open MongoDB.Bson.IO
@@ -12,39 +11,46 @@ type DiscriminatedUnionSerializer<'t>() =
     let CaseNameField = "Case"
     let ValueFieldName = "Fields"
     let Cases = GetUnionCases typeof<'t>
-    let ReadItems (context) (args) (types)  =
+
+    let deserBy context args t =
+        BsonSerializer.LookupSerializer(t).Deserialize(context, args)
+
+    let serBy context args t v =
+        BsonSerializer.LookupSerializer(t).Serialize(context, args, v)
+
+    let ReadItems context args types =
         types 
-        |> Seq.fold(
-            fun state t ->
-                let serializer = BsonSerializer.LookupSerializer(t)
-                let item = serializer.Deserialize(context, args)
-                item::state
-            ) []
+        |> Seq.fold(fun state t -> (deserBy context args t) :: state) []
         |> Seq.toArray
         |> Array.rev
 
     override this.Deserialize(context, args): 't =
         context.Reader.ReadStartDocument()
+
         let name = context.Reader.ReadString(CaseNameField)
         let union = Cases.[name]
+
         context.Reader.ReadName(ValueFieldName)
         context.Reader.ReadStartArray()
+
         let items = ReadItems context args (union.GetFields() |> Seq.map(fun f -> f.PropertyType))
+
         context.Reader.ReadEndArray()
         context.Reader.ReadEndDocument()
+
         FSharpValue.MakeUnion(union, items) :?> 't
 
     override this.Serialize(context, args, value) =
-        let (case, fields) = FSharpValue.GetUnionFields(value, typeof<'t>)
+        let case, fields = FSharpValue.GetUnionFields(value, typeof<'t>)
+
         context.Writer.WriteStartDocument()
         context.Writer.WriteString(CaseNameField, case.Name)
         context.Writer.WriteStartArray(ValueFieldName)
+
         fields 
         |> Seq.zip(case.GetFields()) 
-        |> Seq.iter(fun (field, value) -> 
-            let itemSerializer = BsonSerializer.LookupSerializer(field.PropertyType)
-            itemSerializer.Serialize(context, args, value)
-        )
+        |> Seq.iter(fun (field, value) -> serBy context args field.PropertyType value)
+
         context.Writer.WriteEndArray()
         context.Writer.WriteEndDocument()
 

--- a/NamelessInteractive.FSharp.MongoDB/Helpers.fs
+++ b/NamelessInteractive.FSharp.MongoDB/Helpers.fs
@@ -23,7 +23,10 @@ module internal Helpers =
         objType.IsGenericType &&
         objType.GetGenericTypeDefinition() = typedefof<Set<_>>
 
-    let GetUnionCases objType = FSharpType.GetUnionCases(objType) |> Seq.map(fun x -> (x.Name, x)) |> dict
+    let GetUnionCases objType = 
+        FSharpType.GetUnionCases(objType) 
+        |> Seq.map(fun x -> (x.Name, x)) 
+        |> dict
 
     let IsRecord (objType) =
         FSharpType.IsRecord(objType)

--- a/NamelessInteractive.FSharp.MongoDB/RecordSerializer.fs
+++ b/NamelessInteractive.FSharp.MongoDB/RecordSerializer.fs
@@ -1,12 +1,15 @@
 ﻿namespace NamelessInteractive.FSharp.MongoDB.Serializers
 
+open System.Reflection
 open MongoDB.Bson.Serialization
 open MongoDB.Bson.Serialization.Serializers
+open NamelessInteractive.FSharp.MongoDB
 
 type RecordSerializer<'TRecord>() = 
     inherit SerializerBase<'TRecord>()
     let classMap = BsonClassMap.LookupClassMap(typeof<'TRecord>)
     let serializer = BsonClassMapSerializer(classMap)
+    let fields = GetRecordFields typeof<'TRecord>
 
     override this.Serialize(context, args, value) =
         let mutable nargs = args
@@ -17,3 +20,14 @@ type RecordSerializer<'TRecord>() =
         let mutable nargs = args
         nargs.NominalType <- typeof<'TRecord> 
         serializer.Deserialize(context, nargs)
+
+    interface IBsonDocumentSerializer with
+        member x.TryGetMemberSerializationInfo(memberName, serializationInfo) =
+            if Array.exists (fun (el: PropertyInfo) -> el.Name = memberName) fields then
+                let mm = classMap.GetMemberMap(memberName)
+                serializationInfo <- new BsonSerializationInfo(mm.ElementName, mm.GetSerializer(), mm.MemberType)
+                true
+            else
+                false
+            
+        

--- a/NamelessInteractive.FSharp.MongoDB/RecordSerializer.fs
+++ b/NamelessInteractive.FSharp.MongoDB/RecordSerializer.fs
@@ -1,6 +1,5 @@
 ﻿namespace NamelessInteractive.FSharp.MongoDB.Serializers
 
-open System.Collections.Generic
 open MongoDB.Bson.Serialization
 open MongoDB.Bson.Serialization.Serializers
 
@@ -16,5 +15,5 @@ type RecordSerializer<'TRecord>() =
 
     override this.Deserialize(context, args) =
         let mutable nargs = args
-        nargs.NominalType <- typeof<'TRecord>
+        nargs.NominalType <- typeof<'TRecord> 
         serializer.Deserialize(context, nargs)

--- a/NamelessInteractive.FSharp.MongoDBTests/NamelessInteractive.FSharp.MongoDBTests.fsproj
+++ b/NamelessInteractive.FSharp.MongoDBTests/NamelessInteractive.FSharp.MongoDBTests.fsproj
@@ -53,11 +53,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FsCheck">
-      <HintPath>..\packages\FsCheck.2.0.1\lib\net45\FsCheck.dll</HintPath>
+      <HintPath>..\packages\FsCheck.2.0.4\lib\net45\FsCheck.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsCheck.Xunit">
-      <HintPath>..\packages\FsCheck.Xunit.2.0.1\lib\net45\FsCheck.Xunit.dll</HintPath>
+      <HintPath>..\packages\FsCheck.Xunit.2.0.4\lib\net45\FsCheck.Xunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core">

--- a/NamelessInteractive.FSharp.MongoDBTests/NamelessInteractive.FSharp.MongoDBTests.fsproj
+++ b/NamelessInteractive.FSharp.MongoDBTests/NamelessInteractive.FSharp.MongoDBTests.fsproj
@@ -95,6 +95,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Utils.fs" />
     <Compile Include="UnitTest.fs" />
     <None Include="App.config" />
     <None Include="MSTest.runsettings" />

--- a/NamelessInteractive.FSharp.MongoDBTests/UnitTest.fs
+++ b/NamelessInteractive.FSharp.MongoDBTests/UnitTest.fs
@@ -1,10 +1,11 @@
-﻿namespace UnitTestProject1
+﻿namespace NamelessInteractive.FSharp.MongoDBTests
 
 open System
 open Microsoft.VisualStudio.TestTools.UnitTesting
 
 open MongoDB.Bson
 open MongoDB.Driver
+open MongoDB.Bson.Serialization
 
 type RecTest = 
         {
@@ -68,7 +69,6 @@ type UnitTest() =
                 RecTest.Bar = "Baz"
             }
 
-        let serializer = MongoDB.Bson.Serialization.BsonSerializer.LookupSerializer(testCase.GetType())
         let collection = database.GetCollection<RecTest>("RecTest")
         collection.DeleteManyAsync(wildcard) |> ignore
         collection.InsertOneAsync(testCase).Wait() |> ignore
@@ -88,11 +88,11 @@ type UnitTest() =
                 RecTestWithUnion.Bar4 = UnionTest.TestCase4(3.14M)
                 RecTestWithUnion.Bar5 = UnionTest.TestCase5(true)
                 RecTestWithUnion.Bar6 = UnionTest.TestCase6({ RecTest.Id = "Moo"; RecTest.Foo = 5; RecTest.Bar = "Baz"})
-                RecTestWithUnion.Bar7 = UnionTest.TestCase7 (None)
+                RecTestWithUnion.Bar7 = UnionTest.TestCase7(None)
                 RecTestWithUnion.Bar8 = UnionTest.TestCase8 
-                RecTestWithUnion.Bar9 = [1;2;3;4;5]
+                RecTestWithUnion.Bar9 = [1; 2; 3; 4; 5]
             }
-        let serializer = MongoDB.Bson.Serialization.BsonSerializer.LookupSerializer(testCase.GetType())
+
         let collection = database.GetCollection<RecTestWithUnion>("RecTestWithUnion")
         collection.DeleteManyAsync(wildcard).Wait() |> ignore
         collection.InsertOneAsync(testCase).Wait() |> ignore
@@ -106,8 +106,8 @@ type UnitTest() =
             {
                 SmallTest.Foo = UnionTest.TestCase7 None
             }
-        let serializer = MongoDB.Bson.Serialization.BsonSerializer.LookupSerializer(testCase.GetType())
-        let collection = database.GetCollection<SmallTest>("RecTestWithUnion")
+       
+        let collection = database.GetCollection<SmallTest>("SmallTest")
         collection.DeleteManyAsync(wildcard).Wait() |> ignore
         collection.InsertOneAsync(testCase).Wait() |> ignore
         let saved = collection.Find(wildcard).FirstAsync().Result

--- a/NamelessInteractive.FSharp.MongoDBTests/UnitTest.fs
+++ b/NamelessInteractive.FSharp.MongoDBTests/UnitTest.fs
@@ -112,3 +112,12 @@ type UnitTest() =
         collection.InsertOneAsync(testCase).Wait() |> ignore
         let saved = collection.Find(wildcard).FirstAsync().Result
         Assert.AreEqual(testCase,saved)
+
+    [<TestMethod>]
+    member x.TestMethod4 () =
+        let collection = database.GetCollection<RecTest>("RecTest")
+        let serializer = BsonSerializer.LookupSerializer(typeof<RecTest>) :?> IBsonSerializer<RecTest>
+
+        let index = Builders<RecTest>.IndexKeys.Ascending(propertyEx <@ fun (ev: RecTest) -> ev.Id @>)
+        let _ = index.Render(serializer, collection.Settings.SerializerRegistry)
+        ()

--- a/NamelessInteractive.FSharp.MongoDBTests/Utils.fs
+++ b/NamelessInteractive.FSharp.MongoDBTests/Utils.fs
@@ -1,0 +1,23 @@
+﻿[<AutoOpen>]
+module Utils
+
+open System
+open System.Linq.Expressions
+open Microsoft.FSharp.Quotations
+open Microsoft.FSharp.Quotations.Patterns
+
+/// <summary>
+/// Converts a lambda quotation into a lambda expression
+/// </summary>
+/// <param name="expr">Quotation to convert</param>
+let propertyEx (expr: Expr<'a -> 'b>): Expression<Func<'a, obj>> =
+    match expr with
+    | Lambda(_, body) ->
+        match body with
+        | PropertyGet(_, pinfo, _) ->
+            let arg = Expression.Parameter(typeof<'a>, "arg")
+            let getter = Expression.Property(arg, pinfo) :> Expression
+            let convert = Expression.Convert(getter, typeof<obj>)
+            Expression.Lambda<Func<'a, obj>>(convert, arg)
+        | _ -> failwith "getProperty translator accepts only quotations with property getters"
+    | _ -> failwith "Quotation does not contain lambda function"

--- a/NamelessInteractive.FSharp.MongoDBTests/packages.config
+++ b/NamelessInteractive.FSharp.MongoDBTests/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsCheck" version="2.0.1" targetFramework="net451" userInstalled="true" />
-  <package id="FsCheck.Xunit" version="2.0.1" targetFramework="net451" userInstalled="true" />
-  <package id="FSharp.Core" version="3.1.2.1" targetFramework="net451" userInstalled="true" />
-  <package id="MongoDB.Bson" version="2.0.1" targetFramework="net451" userInstalled="true" />
-  <package id="MongoDB.Driver" version="2.0.1" targetFramework="net451" userInstalled="true" />
-  <package id="MongoDB.Driver.Core" version="2.0.1" targetFramework="net451" userInstalled="true" />
-  <package id="xunit" version="2.0.0" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net451" userInstalled="true" />
+  <package id="FsCheck" version="2.0.4" targetFramework="net451" />
+  <package id="FsCheck.Xunit" version="2.0.4" targetFramework="net451" />
+  <package id="FSharp.Core" version="3.1.2.1" targetFramework="net451" />
+  <package id="MongoDB.Bson" version="2.0.1" targetFramework="net451" />
+  <package id="MongoDB.Driver" version="2.0.1" targetFramework="net451" />
+  <package id="MongoDB.Driver.Core" version="2.0.1" targetFramework="net451" />
+  <package id="xunit" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This PR fixes issue with querying collections of F# record types. Since mongo driver's query API uses LINQ expressions, record types must be properly mapped with IBsonDocumentSerializer.
PR also includes a minimal test case for the issue.
