### PR TITLE
List serializer does not properly serialize lists in Mongo

### DIFF
--- a/NamelessInteractive.FSharp.MongoDB/ListSerializer.fs
+++ b/NamelessInteractive.FSharp.MongoDB/ListSerializer.fs
@@ -7,11 +7,11 @@ open MongoDB.Bson.Serialization.Serializers
 type ListSerializer<'ElemType>() = 
     inherit SerializerBase<'ElemType list>()
     
-    let serializer = EnumerableInterfaceImplementerSerializer<List<'ElemType>, 'ElemType>()
-
-    override this.Serialize(context, args, value) =
-        serializer.Serialize(context, args, new List<'ElemType>(value))
-
+    let serializer = EnumerableInterfaceImplementerSerializer<ResizeArray<'ElemType>, 'ElemType>()
+    
+    override this.Serialize(context, _, value) =
+        serializer.Serialize(context, ResizeArray(value))
+        
     override this.Deserialize(context, args) =
         let res = serializer.Deserialize(context, args)
         res |> unbox |> List.ofSeq<'ElemType>


### PR DESCRIPTION
When saving a list to Mongo, even in the provided tests, the format is saved like this:

{"_t": "List`1", "_v": [1,2,3]}

The tests pass as when this is deserialized it is restored to [1,2,3].

Further work may be needed to improve the tests to check that the Json serialized format is actually as expected.